### PR TITLE
Fix last tweet scraping

### DIFF
--- a/app/routers/get-last-tweet.coffee
+++ b/app/routers/get-last-tweet.coffee
@@ -7,12 +7,14 @@ module.exports = (app) ->
     url = "https://twitter.com/" + req.params.username
     request url, (err, rrr, body) ->
       $ = cheerio.load(body)
-      tweet = $(".tweet-text").html()
-      fullName = $(".stream-item-header .fullname").html()
-      userName = $(".stream-item-header .username").html()
-      timeStamp = $(".stream-item-header ._timestamp").html()
-      avatarURL = $(".stream-item-header img").attr("src")
-      isRetweeted = $(".js-retweet-text").html()  if $(".js-retweet-text a").attr("href").substr(1).toLowerCase() isnt $(".stream-item-header .username b").html().toLowerCase() if $(".js-retweet-text").html() isnt null
+      $last = $('.js-tweet').first()
+      data = $last.data()
+      tweet = $last.find('.js-tweet-text').html().trim()
+      fullName = data.name
+      userName = data.screenName
+      timeStamp = $last.find('.js-short-timestamp').html().trim()
+      avatarURL = $last.find('.js-action-profile-avatar').attr('src')
+      isRetweeted = data.retweeter ? $last.find('.js-retweet-text').text().trim() : null
       if tweet is null
         tweet = "This user's tweets are protected."
         avatarURL = "/images/protected.png"


### PR DESCRIPTION
Funny thing is, those jQuery selectors work fine in DevTools. So, twitter must be serving a different page to `request`.

Anyway, this gets it working again.

![last](https://cloud.githubusercontent.com/assets/357481/3006847/98224458-de53-11e3-931f-16d24f641bb1.png)

![last-djm](https://cloud.githubusercontent.com/assets/357481/3006848/9ce6097a-de53-11e3-8b08-ddeb1fc172fa.png)
